### PR TITLE
fix: hide copy button for codeblocks

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,11 @@ pre {
   white-space: pre-wrap !important;
 }
 
+/* Hide copy button for code blocks */
+pre + div.zeroclipboard-container {
+  display: none;
+}
+
 @page {
   size: auto;
   margin: 54pt;


### PR DESCRIPTION
It doesn't make much sense to keep the button shown since we are printing. It also seems to overflow the button to new line on my machine, but not on provided tests.

PDFs created with:
Windows 10 Home 22H2 19045.3930
2560 x 1600 display (150% scaling)
Chrome: 121.0.6167.185 (Official Build) (64-bit)
Incognito tab with only GitHub Markdown Printer extension enabled

Print options:
![image](https://github.com/jerry1100/github-markdown-printer/assets/12035264/7c1463e5-3962-4df5-8c27-c7e420880bcf)

PDFs before:
- [project-root.pdf](https://github.com/jerry1100/github-markdown-printer/files/14298884/project-root.pdf)
- [folder-root.pdf](https://github.com/jerry1100/github-markdown-printer/files/14298950/folder-root.pdf)
- [readme-file.pdf](https://github.com/jerry1100/github-markdown-printer/files/14298948/readme-file.pdf)
- [wiki.pdf](https://github.com/jerry1100/github-markdown-printer/files/14298951/wiki.pdf)

PDFs after:
- [project-root.pdf](https://github.com/jerry1100/github-markdown-printer/files/14299051/project-root.pdf)
- [folder-root.pdf](https://github.com/jerry1100/github-markdown-printer/files/14299053/folder-root.pdf)
- [readme-file.pdf](https://github.com/jerry1100/github-markdown-printer/files/14299060/readme-file.pdf)
- [wiki.pdf](https://github.com/jerry1100/github-markdown-printer/files/14299064/wiki.pdf)
