### PR TITLE
Create context menu entry only on GitHub.com pages

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -9,6 +9,7 @@ chrome.action.onClicked.addListener((tab) => {
 chrome.contextMenus.create({
   title: 'Print GitHub Markdown',
   id: GITHUB_MARKDOWN_PRINTER,
+  documentUrlPatterns: ["https://github.com/*"]
 });
 
 // Respond to context menu clicks


### PR DESCRIPTION
Currently this extension is creating its context menu entry on all web pages, which is not intended if I'm not wrong. This PR uses `documentUrlPatterns` property to restrict context menu entry only on the github.com pages.

Reference: https://developer.chrome.com/docs/extensions/reference/api/contextMenus#properties