### PR TITLE
Add keyboard shortcut (Alt+P) for printing

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,13 @@
 const GITHUB_MARKDOWN_PRINTER = 'GITHUB_MARKDOWN_PRINTER';
 
+// Respond to keyboard shortcut commands
+chrome.commands.onCommand.addListener((command) => {
+  chrome.tabs.query({ active: true, lastFocusedWindow: true }, function (tabs) {
+    let currentTab = tabs[0];
+    printPageForTab(currentTab.id);
+  });
+});
+
 // Respond to clicks on the extension icon
 chrome.action.onClicked.addListener((tab) => {
   printPageForTab(tab.id);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,5 +26,14 @@
       "resources": ["style.css"],
       "matches": ["https://*.github.com/*"]
     }
-  ]
+  ],
+  "host_permissions": ["https://*.github.com/*"],
+  "commands": {
+    "print": {
+      "suggested_key": {
+        "default": "Alt+P"
+      },
+      "description": "Attempts to print the markdown"
+    }
+  }
 }


### PR DESCRIPTION
Fixes #36
- Added keyboard shortcut to print the markdown
- Added permission for the github host site for accessing tab data from keyboard command.